### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - default
 dependencies:
   # - pangeo-notebook
+  - jinja2<3.1
   - python==3.8
   - jupyterlab
   # - jupyter-lab<3.3.0


### PR DESCRIPTION
I was obtaining an error when importing hvplot.xarray.
ImportError: cannot import name 'Markup' from 'jinja2'
I tried a few things, that resulted in other errors.

The fix that worked for me was to downgrade jinja2 to a version less than 3.1 in the environment.yaml and then I recreated the environment.

conda env create -f ./environment.yml --force
With this modification, I was able to successfully run thru the tutorial. Thanks!